### PR TITLE
Add vma support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,15 @@ exclude = [
     "compile_shaders.*"
 ]
 
+[features]
+vma = ["vk-mem"]
+
 [dependencies]
 log = "0.4"
 imgui = "^0.6"
 ash = ">=0.29"
 ultraviolet = "0.7"
+vk-mem = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 simple_logger = "1.11"

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -7,7 +7,7 @@ use ash::{
     vk, Device, Entry, Instance,
 };
 use imgui::*;
-use imgui_rs_vulkan_renderer::*;
+use imgui_rs_vulkan_renderer::{Renderer, RendererVkContext};
 use imgui_winit_support::{HiDpiMode, WinitPlatform};
 use std::{
     error::Error,

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -3,7 +3,10 @@ mod common;
 use ash::{version::DeviceV1_0, vk};
 use common::*;
 use imgui::*;
-use imgui_rs_vulkan_renderer::vulkan::*;
+use imgui_rs_vulkan_renderer::vulkan::{
+    create_vulkan_descriptor_pool, create_vulkan_descriptor_set,
+    create_vulkan_descriptor_set_layout, Allocator, Texture,
+};
 use imgui_rs_vulkan_renderer::RendererVkContext;
 
 use std::error::Error;

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -66,6 +66,7 @@ impl CustomTexturesApp {
                 vk_context.queue(),
                 vk_context.command_pool(),
                 memory_properties,
+                &None,
                 WIDTH as u32,
                 HEIGHT as u32,
                 &data,
@@ -144,6 +145,7 @@ impl Lenna {
             vk_context.queue(),
             vk_context.command_pool(),
             memory_properties,
+            &None,
             width,
             height,
             &data,
@@ -183,7 +185,7 @@ impl Lenna {
         unsafe {
             let device = context.device();
             device.destroy_descriptor_pool(self.descriptor_pool, None);
-            self.texture.destroy(device);
+            self.texture.destroy(device, &None);
             device.destroy_descriptor_set_layout(self.descriptor_set_layout, None);
         }
     }
@@ -194,7 +196,7 @@ impl App for CustomTexturesApp {
         unsafe {
             let device = context.device();
             device.destroy_descriptor_pool(self.descriptor_pool, None);
-            self.my_texture.destroy(device);
+            self.my_texture.destroy(device, &None);
             if let Some(lenna) = &mut self.lenna {
                 lenna.destroy(context);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,6 @@ mod renderer;
 
 pub use error::*;
 pub use renderer::*;
+
+#[cfg(feature = "vma")]
+extern crate vk_mem;

--- a/src/renderer/allocator.rs
+++ b/src/renderer/allocator.rs
@@ -1,0 +1,212 @@
+use crate::{RendererResult, RendererVkContext};
+use ash::{prelude::VkResult, vk};
+#[cfg(not(feature = "vma"))]
+use ash::{
+    version::{DeviceV1_0, InstanceV1_0},
+    Device,
+};
+use core::ffi::c_void;
+
+#[cfg(not(feature = "vma"))]
+pub(crate) type Memory = vk::DeviceMemory;
+
+#[cfg(not(feature = "vma"))]
+pub(crate) struct Allocator {
+    device: Device,
+    memory_properties: vk::PhysicalDeviceMemoryProperties,
+}
+
+#[cfg(not(feature = "vma"))]
+impl Allocator {
+    pub fn new(vk_context: &dyn RendererVkContext, _frame_in_use_count: u32) -> Self {
+        let memory_properties = unsafe {
+            vk_context
+                .instance()
+                .get_physical_device_memory_properties(vk_context.physical_device())
+        };
+        Allocator {
+            device: vk_context.device().clone(), // !!!
+            memory_properties,
+        }
+    }
+
+    pub fn destroy(&mut self) {}
+
+    pub fn create_buffer(
+        &self,
+        buffer_create_info: &vk::BufferCreateInfo,
+    ) -> RendererResult<(vk::Buffer, Memory)> {
+        let buffer = unsafe { self.device.create_buffer(&buffer_create_info, None)? };
+        let mem_requirements = unsafe { self.device.get_buffer_memory_requirements(buffer) };
+        let mem_type = Self::find_memory_type(
+            mem_requirements,
+            self.memory_properties,
+            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+        );
+        let memory_allocate_info = vk::MemoryAllocateInfo::builder()
+            .allocation_size(mem_requirements.size)
+            .memory_type_index(mem_type);
+        let memory = unsafe {
+            let memory = self.device.allocate_memory(&memory_allocate_info, None)?;
+            self.device.bind_buffer_memory(buffer, memory, 0)?;
+            memory
+        };
+        Ok((buffer, memory))
+    }
+
+    pub fn destroy_buffer(&self, buffer: vk::Buffer, memory: &Memory) {
+        unsafe {
+            self.device.destroy_buffer(buffer, None);
+            self.device.free_memory(*memory, None);
+        }
+    }
+
+    pub fn map_memory(&self, memory: &vk::DeviceMemory) -> VkResult<*mut c_void> {
+        unsafe {
+            self.device
+                .map_memory(*memory, 0, vk::WHOLE_SIZE, vk::MemoryMapFlags::default())
+        }
+    }
+
+    pub fn unmap_memory(&self, memory: &vk::DeviceMemory) {
+        unsafe { self.device.unmap_memory(*memory) }
+    }
+
+    pub fn create_image(
+        &self,
+        image_create_info: &vk::ImageCreateInfo,
+    ) -> RendererResult<(vk::Image, Memory)> {
+        let image = unsafe { self.device.create_image(&image_create_info, None)? };
+        let mem_requirements = unsafe { self.device.get_image_memory_requirements(image) };
+        let mem_type_index = Self::find_memory_type(
+            mem_requirements,
+            self.memory_properties,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        );
+        let memory_allocate_info = vk::MemoryAllocateInfo::builder()
+            .allocation_size(mem_requirements.size)
+            .memory_type_index(mem_type_index);
+        let memory = unsafe {
+            let memory = self.device.allocate_memory(&memory_allocate_info, None)?;
+            self.device.bind_image_memory(image, memory, 0)?;
+            memory
+        };
+        Ok((image, memory))
+    }
+
+    pub fn destroy_image(&self, image: vk::Image, memory: &Memory) {
+        unsafe {
+            self.device.destroy_image(image, None);
+            self.device.free_memory(*memory, None);
+        }
+    }
+
+    fn find_memory_type(
+        requirements: vk::MemoryRequirements,
+        mem_properties: vk::PhysicalDeviceMemoryProperties,
+        required_properties: vk::MemoryPropertyFlags,
+    ) -> u32 {
+        for i in 0..mem_properties.memory_type_count {
+            if requirements.memory_type_bits & (1 << i) != 0
+                && mem_properties.memory_types[i as usize]
+                    .property_flags
+                    .contains(required_properties)
+            {
+                return i;
+            }
+        }
+        panic!("Failed to find suitable memory type.")
+    }
+}
+
+#[cfg(feature = "vma")]
+use vk_mem;
+
+#[cfg(feature = "vma")]
+pub(crate) type Memory = vk_mem::Allocation;
+
+#[cfg(feature = "vma")]
+pub(crate) struct Allocator {
+    allocator: vk_mem::Allocator,
+}
+
+#[cfg(feature = "vma")]
+impl Allocator {
+    pub fn new(vk_context: &dyn RendererVkContext, frame_in_use_count: u32) -> Self {
+        let allocator = {
+            let create_info = vk_mem::AllocatorCreateInfo {
+                physical_device: vk_context.physical_device(),
+                device: vk_context.device().clone(),
+                instance: vk_context.instance().clone(),
+                flags: vk_mem::AllocatorCreateFlags::NONE,
+                preferred_large_heap_block_size: 0,
+                frame_in_use_count,
+                heap_size_limits: None,
+            };
+            let allocator = match vk_mem::Allocator::new(&create_info) {
+                Ok(v) => v,
+                Err(e) => panic!(e.to_string()),
+            };
+            allocator
+        };
+        Allocator { allocator }
+    }
+
+    pub fn destroy(&mut self) {
+        self.allocator.destroy();
+    }
+
+    pub fn create_buffer(
+        &self,
+        buffer_create_info: &vk::BufferCreateInfo,
+    ) -> RendererResult<(vk::Buffer, Memory)> {
+        let allocation_create_info = vk_mem::AllocationCreateInfo {
+            usage: vk_mem::MemoryUsage::CpuToGpu,
+            ..Default::default()
+        };
+
+        let (buffer, allocation, _allocation_info) = self
+            .allocator
+            .create_buffer(&buffer_create_info, &allocation_create_info)
+            .unwrap();
+
+        Ok((buffer, allocation))
+    }
+
+    pub fn destroy_buffer(&self, buffer: vk::Buffer, memory: &Memory) {
+        self.allocator
+            .destroy_buffer(buffer, memory)
+            .expect("Failed to destroy buffer!");
+    }
+
+    pub fn map_memory(&self, memory: &vk_mem::Allocation) -> VkResult<*mut c_void> {
+        Ok(self.allocator.map_memory(memory).unwrap() as _)
+    }
+
+    pub fn unmap_memory(&self, memory: &vk_mem::Allocation) {
+        self.allocator.unmap_memory(memory).unwrap()
+    }
+
+    pub fn create_image(
+        &self,
+        image_create_info: &vk::ImageCreateInfo,
+    ) -> RendererResult<(vk::Image, Memory)> {
+        let allocation_create_info = vk_mem::AllocationCreateInfo {
+            usage: vk_mem::MemoryUsage::GpuOnly,
+            ..Default::default()
+        };
+
+        let (image, allocation, _allocation_info) = self
+            .allocator
+            .create_image(&image_create_info, &allocation_create_info)
+            .unwrap();
+
+        Ok((image, allocation))
+    }
+
+    pub fn destroy_image(&self, image: vk::Image, memory: &Memory) {
+        self.allocator
+            .destroy_image(image, memory)
+            .expect("Failed to destroy image!");
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,9 +1,10 @@
-pub mod vulkan;
+pub(crate) mod allocator;
+pub(crate) mod vulkan;
 
-use crate::RendererError;
+use crate::{allocator::Allocator, RendererError};
 use ash::{version::DeviceV1_0, vk, Device, Instance};
 use imgui::{Context, DrawCmd, DrawCmdParams, DrawData, TextureId, Textures};
-use mesh::*;
+use mesh::Mesh;
 use ultraviolet::projection::orthographic_vk;
 use vulkan::*;
 
@@ -35,7 +36,7 @@ pub trait RendererVkContext {
 
     /// Return a Vulkan command pool.
     ///
-    /// The pool will be used to allocate command buffers to upload textures to the gpu.
+    /// The pool will be used to allocate command buffers.
     fn command_pool(&self) -> vk::CommandPool;
 }
 
@@ -475,14 +476,13 @@ impl Frames {
 
 mod mesh {
 
-    use super::{vulkan::*, RendererVkContext};
-    use crate::RendererResult;
+    use super::{allocator::*, vulkan::*, RendererResult, RendererVkContext};
     use ash::{vk, Device};
     use imgui::{DrawData, DrawVert};
     use std::mem::size_of_val;
 
     /// Vertex and index buffer resources for one frame in flight.
-    pub struct Mesh {
+    pub(super) struct Mesh {
         pub vertex_buffer: vk::Buffer,
         vertex_memory: Memory,
         vertex_count: usize,


### PR DESCRIPTION
Work in progress to add VMA support using [vk_mem_rs](https://github.com/gwihlidal/vk-mem-rs).

Some noteworthy things:
- added a "vma" feature
- defined a `Memory` type which maps to `vk::DeviceMemory` by default and to `vk_mem::Allocation` when enabling the "vma" feature (this is a trick),
- added an `Allocator` struct that abstracts out how to work with buffers, images and memory.

Some issues:
- user provided allocator is not yet implemented
- had to add `allocator` argument to many functions (position where it is added is not consistent)
- test code is impacted in a bad way (some imgui-rs-wulkan internal functions are exposed to and used by tests...)

Biggest problems in my opinion are:

1/ The `Allocator` abstraction needs to clone the device.
This cloning is artificial and could be avoided in the non VMA case.
But for the VMA case it is mandatory as the vk_mem_rs mandates it (see [`AllocatorCreateInfo`](https://docs.rs/vk-mem/0.2.2/vk_mem/struct.AllocatorCreateInfo.html#structfield.devicel)).

It should be possible to get rid of this cloning for the non VMA case.
For the VMA case, it is possible to get rid of it too by making it mandatory for the user to provide the allocator (make it a user problem...).
But this would mean no support for "internal" only use of VMA.

2/ Many function now take `device` _and_ `allocator` arguments which is messy.

3/ Test code that uses internal functions.
See custom_textures.rs.
