### PR TITLE
Support depth state in pipeline

### DIFF
--- a/src/renderer/vulkan.rs
+++ b/src/renderer/vulkan.rs
@@ -169,6 +169,14 @@ pub(crate) fn create_vulkan_pipeline(
     let dynamic_states_info =
         vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
 
+    let depth_stencil_state_create_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        .depth_test_enable(true)
+        .depth_write_enable(true)
+        .depth_compare_op(vk::CompareOp::ALWAYS)
+        .depth_bounds_test_enable(false)
+        .stencil_test_enable(false)
+        .build();
+
     let pipeline_info = [vk::GraphicsPipelineCreateInfo::builder()
         .stages(&shader_states_infos)
         .vertex_input_state(&vertex_input_info)
@@ -181,6 +189,7 @@ pub(crate) fn create_vulkan_pipeline(
         .layout(pipeline_layout)
         .render_pass(render_pass)
         .subpass(0)
+        .depth_stencil_state(&depth_stencil_state_create_info)
         .build()];
 
     let pipeline = unsafe {


### PR DESCRIPTION
We are trying to replace the forked `imgui-rs-vulkan-renderer` dependency in [OpenPAL3](https://github.com/dontpanic92/OpenPAL3) with this upstream after the pipeline supports depth/stencil test. :)