### PR TITLE
bump gpu-allocator to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ imgui = "^0.11"
 ash = { version = ">=0.34, <=0.37", default-features = false, features = ["debug"] }
 ultraviolet = "0.9"
 
-gpu-allocator = { version = "0.23", default-features = false, features = ["vulkan"], optional = true }
+gpu-allocator = { version = "0.25", default-features = false, features = ["vulkan"], optional = true }
 
 vk-mem = { version = "0.2", optional = true }
 


### PR DESCRIPTION
gpu-allocator version can be bumped to 0.25 with no further modifications