### PR TITLE
Bump ash to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,22 @@ include = ["/src", "LICENSE", "README.md", "CHANGELOG.md"]
 thiserror = "1.0"
 log = "0.4"
 imgui = "^0.12"
-ash = { version = ">=0.34, <=0.37", default-features = false, features = ["debug"] }
+ash = { version = "0.38", default-features = false, features = ["debug"] }
 ultraviolet = "0.9"
 
-gpu-allocator = { version = "0.26", default-features = false, features = ["vulkan"], optional = true }
+gpu-allocator = { version = "0.27", default-features = false, features = ["vulkan"], optional = true }
 
-vk-mem = { version = "0.3", optional = true }
+vk-mem = { version = "0.4", optional = true }
 
 [features]
 dynamic-rendering = []
 
 [dev-dependencies]
 simple_logger = "5.0"
-winit = { version = "0.29", default-features = false, features = ["rwh_05", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]}
+winit = "0.29"
 imgui = { version = "^0.12", features = ["tables-api"] }
 imgui-winit-support = "^0.12"
-ash = { version = "0.37", default-features = false, features = ["debug", "linked"] }
-ash-window = "0.12"
-raw-window-handle = "0.5"
+ash = { version = "0.38", default-features = false, features = ["debug", "linked"] }
+ash-window = "0.13"
 image = "0.25"
 imgui-rs-vulkan-renderer = { path = ".", features = ["gpu-allocator"] }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,14 +1,11 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain as SwapchainLoader},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
 use imgui::*;
 use imgui_rs_vulkan_renderer::*;
 use imgui_winit_support::{HiDpiMode, WinitPlatform};
-use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use std::{
     error::Error,
     ffi::{CStr, CString},
@@ -20,6 +17,7 @@ use winit::{
     dpi::PhysicalSize,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
+    raw_window_handle::{HasDisplayHandle, HasWindowHandle},
     window::{Window, WindowBuilder},
 };
 #[cfg(feature = "gpu-allocator")]
@@ -70,7 +68,7 @@ impl<A: App> System<A> {
         let vulkan_context = VulkanContext::new(&window, title)?;
 
         let command_buffer = {
-            let allocate_info = vk::CommandBufferAllocateInfo::builder()
+            let allocate_info = vk::CommandBufferAllocateInfo::default()
                 .command_pool(vulkan_context.command_pool)
                 .level(vk::CommandBufferLevel::PRIMARY)
                 .command_buffer_count(1);
@@ -86,7 +84,7 @@ impl<A: App> System<A> {
 
         // Semaphore use for presentation
         let image_available_semaphore = {
-            let semaphore_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_info = vk::SemaphoreCreateInfo::default();
             unsafe {
                 vulkan_context
                     .device
@@ -94,7 +92,7 @@ impl<A: App> System<A> {
             }
         };
         let render_finished_semaphore = {
-            let semaphore_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_info = vk::SemaphoreCreateInfo::default();
             unsafe {
                 vulkan_context
                     .device
@@ -102,7 +100,7 @@ impl<A: App> System<A> {
             }
         };
         let fence = {
-            let fence_info = vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            let fence_info = vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
             unsafe { vulkan_context.device.create_fence(&fence_info, None)? }
         };
 
@@ -348,12 +346,11 @@ impl<A: App> System<A> {
                     .expect("Failed to record command buffer");
 
                     let command_buffers = [command_buffer];
-                    let submit_info = [vk::SubmitInfo::builder()
+                    let submit_info = [vk::SubmitInfo::default()
                         .wait_semaphores(&wait_semaphores)
                         .wait_dst_stage_mask(&wait_stages)
                         .command_buffers(&command_buffers)
-                        .signal_semaphores(&signal_semaphores)
-                        .build()];
+                        .signal_semaphores(&signal_semaphores)];
                     unsafe {
                         vulkan_context
                             .device
@@ -363,7 +360,7 @@ impl<A: App> System<A> {
 
                     let swapchains = [swapchain.khr];
                     let images_indices = [image_index];
-                    let present_info = vk::PresentInfoKHR::builder()
+                    let present_info = vk::PresentInfoKHR::default()
                         .wait_semaphores(&signal_semaphores)
                         .swapchains(&swapchains)
                         .image_indices(&images_indices);
@@ -437,9 +434,9 @@ impl<A: App> System<A> {
 pub struct VulkanContext {
     _entry: Entry,
     pub instance: Instance,
-    debug_utils: DebugUtils,
+    debug_utils: debug_utils::Instance,
     debug_utils_messenger: vk::DebugUtilsMessengerEXT,
-    surface: Surface,
+    surface: surface::Instance,
     surface_khr: vk::SurfaceKHR,
     pub physical_device: vk::PhysicalDevice,
     graphics_q_index: u32,
@@ -458,13 +455,13 @@ impl VulkanContext {
             create_vulkan_instance(&entry, window, name)?;
 
         // Vulkan surface
-        let surface = Surface::new(&entry, &instance);
+        let surface = surface::Instance::new(&entry, &instance);
         let surface_khr = unsafe {
             ash_window::create_surface(
                 &entry,
                 &instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window.display_handle().unwrap().into(),
+                window.window_handle().unwrap().into(),
                 None,
             )?
         };
@@ -488,7 +485,7 @@ impl VulkanContext {
 
         // Command pool & buffer
         let command_pool = {
-            let command_pool_info = vk::CommandPoolCreateInfo::builder()
+            let command_pool_info = vk::CommandPoolCreateInfo::default()
                 .queue_family_index(graphics_q_index)
                 .flags(vk::CommandPoolCreateFlags::empty());
             unsafe { device.create_command_pool(&command_pool_info, None)? }
@@ -527,7 +524,7 @@ impl Drop for VulkanContext {
 }
 
 struct Swapchain {
-    loader: SwapchainLoader,
+    loader: swapchain::Device,
     extent: vk::Extent2D,
     khr: vk::SwapchainKHR,
     images: Vec<vk::Image>,
@@ -624,12 +621,12 @@ fn create_vulkan_instance(
     entry: &Entry,
     window: &Window,
     title: &str,
-) -> Result<(Instance, DebugUtils, vk::DebugUtilsMessengerEXT), Box<dyn Error>> {
+) -> Result<(Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT), Box<dyn Error>> {
     log::debug!("Creating vulkan instance");
     // Vulkan instance
     let app_name = CString::new(title)?;
     let engine_name = CString::new("No Engine")?;
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(app_name.as_c_str())
         .application_version(vk::make_api_version(0, 0, 1, 0))
         .engine_name(engine_name.as_c_str())
@@ -637,17 +634,18 @@ fn create_vulkan_instance(
         .api_version(vk::make_api_version(0, 1, 0, 0));
 
     let mut extension_names =
-        ash_window::enumerate_required_extensions(window.raw_display_handle())?.to_vec();
-    extension_names.push(DebugUtils::name().as_ptr());
+        ash_window::enumerate_required_extensions(window.display_handle().unwrap().into())?
+            .to_vec();
+    extension_names.push(debug_utils::NAME.as_ptr());
 
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
 
     let instance = unsafe { entry.create_instance(&instance_create_info, None)? };
 
     // Vulkan debug report
-    let create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    let create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::INFO
@@ -660,7 +658,7 @@ fn create_vulkan_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
         .pfn_user_callback(Some(vulkan_debug_callback));
-    let debug_utils = DebugUtils::new(entry, &instance);
+    let debug_utils = debug_utils::Instance::new(entry, &instance);
     let debug_utils_messenger =
         unsafe { debug_utils.create_debug_utils_messenger(&create_info, None)? };
 
@@ -687,7 +685,7 @@ unsafe extern "system" fn vulkan_debug_callback(
 
 fn create_vulkan_physical_device_and_get_graphics_and_present_qs_indices(
     instance: &Instance,
-    surface: &Surface,
+    surface: &surface::Instance,
     surface_khr: vk::SurfaceKHR,
 ) -> Result<(vk::PhysicalDevice, u32, u32), Box<dyn Error>> {
     log::debug!("Creating vulkan physical device");
@@ -733,9 +731,9 @@ fn create_vulkan_physical_device_and_get_graphics_and_present_qs_indices(
                     .enumerate_device_extension_properties(device)
                     .expect("Failed to get device ext properties")
             };
-            let extention_support = extension_props.iter().any(|ext| {
+            let extension_support = extension_props.iter().any(|ext| {
                 let name = unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) };
-                SwapchainLoader::name() == name
+                swapchain::NAME == name
             });
 
             // Does the device have available formats for the given surface
@@ -754,7 +752,7 @@ fn create_vulkan_physical_device_and_get_graphics_and_present_qs_indices(
 
             graphics.is_some()
                 && present.is_some()
-                && extention_support
+                && extension_support
                 && !formats.is_empty()
                 && !present_modes.is_empty()
         })
@@ -784,17 +782,16 @@ fn create_vulkan_device_and_graphics_and_present_qs(
         indices
             .iter()
             .map(|index| {
-                vk::DeviceQueueCreateInfo::builder()
+                vk::DeviceQueueCreateInfo::default()
                     .queue_family_index(*index)
                     .queue_priorities(&queue_priorities)
-                    .build()
             })
             .collect::<Vec<_>>()
     };
 
-    let device_extensions_ptrs = [SwapchainLoader::name().as_ptr()];
+    let device_extensions_ptrs = [swapchain::NAME.as_ptr()];
 
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_extension_names(&device_extensions_ptrs);
 
@@ -806,7 +803,7 @@ fn create_vulkan_device_and_graphics_and_present_qs(
 }
 
 type CreateSwapchainResult = (
-    SwapchainLoader,
+    swapchain::Device,
     vk::SwapchainKHR,
     vk::Extent2D,
     vk::Format,
@@ -894,7 +891,7 @@ fn create_vulkan_swapchain(
         vulkan_context.present_q_index,
     ];
     let create_info = {
-        let mut builder = vk::SwapchainCreateInfoKHR::builder()
+        let mut builder = vk::SwapchainCreateInfoKHR::default()
             .surface(vulkan_context.surface_khr)
             .min_image_count(image_count)
             .image_format(format.format)
@@ -918,7 +915,7 @@ fn create_vulkan_swapchain(
             .clipped(true)
     };
 
-    let swapchain = SwapchainLoader::new(&vulkan_context.instance, &vulkan_context.device);
+    let swapchain = swapchain::Device::new(&vulkan_context.instance, &vulkan_context.device);
     let swapchain_khr = unsafe { swapchain.create_swapchain(&create_info, None)? };
 
     // Swapchain images and image views
@@ -926,7 +923,7 @@ fn create_vulkan_swapchain(
     let views = images
         .iter()
         .map(|image| {
-            let create_info = vk::ImageViewCreateInfo::builder()
+            let create_info = vk::ImageViewCreateInfo::default()
                 .image(*image)
                 .view_type(vk::ImageViewType::TYPE_2D)
                 .format(format.format)
@@ -957,26 +954,23 @@ fn create_vulkan_render_pass(
     format: vk::Format,
 ) -> Result<vk::RenderPass, Box<dyn Error>> {
     log::debug!("Creating vulkan render pass");
-    let attachment_descs = [vk::AttachmentDescription::builder()
+    let attachment_descs = [vk::AttachmentDescription::default()
         .format(format)
         .samples(vk::SampleCountFlags::TYPE_1)
         .load_op(vk::AttachmentLoadOp::CLEAR)
         .store_op(vk::AttachmentStoreOp::STORE)
         .initial_layout(vk::ImageLayout::UNDEFINED)
-        .final_layout(vk::ImageLayout::PRESENT_SRC_KHR)
-        .build()];
+        .final_layout(vk::ImageLayout::PRESENT_SRC_KHR)];
 
-    let color_attachment_refs = [vk::AttachmentReference::builder()
+    let color_attachment_refs = [vk::AttachmentReference::default()
         .attachment(0)
-        .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-        .build()];
+        .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
 
-    let subpass_descs = [vk::SubpassDescription::builder()
+    let subpass_descs = [vk::SubpassDescription::default()
         .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
-        .color_attachments(&color_attachment_refs)
-        .build()];
+        .color_attachments(&color_attachment_refs)];
 
-    let subpass_deps = [vk::SubpassDependency::builder()
+    let subpass_deps = [vk::SubpassDependency::default()
         .src_subpass(vk::SUBPASS_EXTERNAL)
         .dst_subpass(0)
         .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
@@ -984,10 +978,9 @@ fn create_vulkan_render_pass(
         .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
         .dst_access_mask(
             vk::AccessFlags::COLOR_ATTACHMENT_READ | vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
-        )
-        .build()];
+        )];
 
-    let render_pass_info = vk::RenderPassCreateInfo::builder()
+    let render_pass_info = vk::RenderPassCreateInfo::default()
         .attachments(&attachment_descs)
         .subpasses(&subpass_descs)
         .dependencies(&subpass_deps);
@@ -1006,7 +999,7 @@ fn create_vulkan_framebuffers(
         .iter()
         .map(|view| [*view])
         .map(|attachments| {
-            let framebuffer_info = vk::FramebufferCreateInfo::builder()
+            let framebuffer_info = vk::FramebufferCreateInfo::default()
                 .render_pass(render_pass)
                 .attachments(&attachments)
                 .width(extent.width)
@@ -1031,10 +1024,10 @@ fn record_command_buffers(
     unsafe { device.reset_command_pool(command_pool, vk::CommandPoolResetFlags::empty())? };
 
     let command_buffer_begin_info =
-        vk::CommandBufferBeginInfo::builder().flags(vk::CommandBufferUsageFlags::SIMULTANEOUS_USE);
+        vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::SIMULTANEOUS_USE);
     unsafe { device.begin_command_buffer(command_buffer, &command_buffer_begin_info)? };
 
-    let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
+    let render_pass_begin_info = vk::RenderPassBeginInfo::default()
         .render_pass(render_pass)
         .framebuffer(framebuffer)
         .render_area(vk::Rect2D {

--- a/examples/vulkan/buffer.rs
+++ b/examples/vulkan/buffer.rs
@@ -20,11 +20,10 @@ fn create_buffer(
     usage: vk::BufferUsageFlags,
     mem_properties: vk::PhysicalDeviceMemoryProperties,
 ) -> RendererResult<(vk::Buffer, vk::DeviceMemory)> {
-    let buffer_info = vk::BufferCreateInfo::builder()
+    let buffer_info = vk::BufferCreateInfo::default()
         .size(size as _)
         .usage(usage)
-        .sharing_mode(vk::SharingMode::EXCLUSIVE)
-        .build();
+        .sharing_mode(vk::SharingMode::EXCLUSIVE);
     let buffer = unsafe { device.create_buffer(&buffer_info, None)? };
 
     let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
@@ -34,7 +33,7 @@ fn create_buffer(
         vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
     );
 
-    let alloc_info = vk::MemoryAllocateInfo::builder()
+    let alloc_info = vk::MemoryAllocateInfo::default()
         .allocation_size(mem_requirements.size)
         .memory_type_index(mem_type);
     let memory = unsafe { device.allocate_memory(&alloc_info, None)? };

--- a/examples/vulkan/texture.rs
+++ b/examples/vulkan/texture.rs
@@ -70,7 +70,7 @@ impl Texture {
                 depth: 1,
             };
 
-            let image_info = vk::ImageCreateInfo::builder()
+            let image_info = vk::ImageCreateInfo::default()
                 .image_type(vk::ImageType::TYPE_2D)
                 .extent(extent)
                 .mip_levels(1)
@@ -91,7 +91,7 @@ impl Texture {
                 vk::MemoryPropertyFlags::DEVICE_LOCAL,
             );
 
-            let alloc_info = vk::MemoryAllocateInfo::builder()
+            let alloc_info = vk::MemoryAllocateInfo::default()
                 .allocation_size(mem_requirements.size)
                 .memory_type_index(mem_type_index);
             let memory = unsafe {
@@ -106,7 +106,7 @@ impl Texture {
         // Transition the image layout and copy the buffer into the image
         // and transition the layout again to be readable from fragment shader.
         {
-            let mut barrier = vk::ImageMemoryBarrier::builder()
+            let mut barrier = vk::ImageMemoryBarrier::default()
                 .old_layout(vk::ImageLayout::UNDEFINED)
                 .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                 .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -120,8 +120,7 @@ impl Texture {
                     layer_count: 1,
                 })
                 .src_access_mask(vk::AccessFlags::empty())
-                .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
-                .build();
+                .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
 
             unsafe {
                 device.cmd_pipeline_barrier(
@@ -135,7 +134,7 @@ impl Texture {
                 )
             };
 
-            let region = vk::BufferImageCopy::builder()
+            let region = vk::BufferImageCopy::default()
                 .buffer_offset(0)
                 .buffer_row_length(0)
                 .buffer_image_height(0)
@@ -150,8 +149,7 @@ impl Texture {
                     width,
                     height,
                     depth: 1,
-                })
-                .build();
+                });
             unsafe {
                 device.cmd_copy_buffer_to_image(
                     command_buffer,
@@ -181,7 +179,7 @@ impl Texture {
         }
 
         let image_view = {
-            let create_info = vk::ImageViewCreateInfo::builder()
+            let create_info = vk::ImageViewCreateInfo::default()
                 .image(image)
                 .view_type(vk::ImageViewType::TYPE_2D)
                 .format(vk::Format::R8G8B8A8_UNORM)
@@ -197,7 +195,7 @@ impl Texture {
         };
 
         let sampler = {
-            let sampler_info = vk::SamplerCreateInfo::builder()
+            let sampler_info = vk::SamplerCreateInfo::default()
                 .mag_filter(vk::Filter::LINEAR)
                 .min_filter(vk::Filter::LINEAR)
                 .address_mode_u(vk::SamplerAddressMode::REPEAT)
@@ -244,7 +242,7 @@ fn execute_one_time_commands<R, F: FnOnce(vk::CommandBuffer) -> R>(
     executor: F,
 ) -> RendererResult<R> {
     let command_buffer = {
-        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+        let alloc_info = vk::CommandBufferAllocateInfo::default()
             .level(vk::CommandBufferLevel::PRIMARY)
             .command_pool(pool)
             .command_buffer_count(1);
@@ -255,7 +253,7 @@ fn execute_one_time_commands<R, F: FnOnce(vk::CommandBuffer) -> R>(
 
     // Begin recording
     {
-        let begin_info = vk::CommandBufferBeginInfo::builder()
+        let begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe { device.begin_command_buffer(command_buffer, &begin_info)? };
     }
@@ -268,9 +266,7 @@ fn execute_one_time_commands<R, F: FnOnce(vk::CommandBuffer) -> R>(
 
     // Submit and wait
     {
-        let submit_info = vk::SubmitInfo::builder()
-            .command_buffers(&command_buffers)
-            .build();
+        let submit_info = vk::SubmitInfo::default().command_buffers(&command_buffers);
         let submit_infos = [submit_info];
         unsafe {
             device.queue_submit(queue, &submit_infos, vk::Fence::null())?;

--- a/src/renderer/allocator/default.rs
+++ b/src/renderer/allocator/default.rs
@@ -44,11 +44,10 @@ impl Allocate for Allocator {
         size: usize,
         usage: vk::BufferUsageFlags,
     ) -> RendererResult<(vk::Buffer, Self::Memory)> {
-        let buffer_info = vk::BufferCreateInfo::builder()
+        let buffer_info = vk::BufferCreateInfo::default()
             .size(size as _)
             .usage(usage)
-            .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .build();
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
 
         let buffer = unsafe { device.create_buffer(&buffer_info, None)? };
 
@@ -58,7 +57,7 @@ impl Allocate for Allocator {
             vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
         )?;
 
-        let alloc_info = vk::MemoryAllocateInfo::builder()
+        let alloc_info = vk::MemoryAllocateInfo::default()
             .allocation_size(mem_requirements.size)
             .memory_type_index(mem_type);
         let memory = unsafe { device.allocate_memory(&alloc_info, None)? };
@@ -79,7 +78,7 @@ impl Allocate for Allocator {
             depth: 1,
         };
 
-        let image_info = vk::ImageCreateInfo::builder()
+        let image_info = vk::ImageCreateInfo::default()
             .image_type(vk::ImageType::TYPE_2D)
             .extent(extent)
             .mip_levels(1)
@@ -97,7 +96,7 @@ impl Allocate for Allocator {
         let mem_type_index =
             self.find_memory_type(mem_requirements, vk::MemoryPropertyFlags::DEVICE_LOCAL)?;
 
-        let alloc_info = vk::MemoryAllocateInfo::builder()
+        let alloc_info = vk::MemoryAllocateInfo::default()
             .allocation_size(mem_requirements.size)
             .memory_type_index(mem_type_index);
         let memory = unsafe {

--- a/src/renderer/allocator/gpu.rs
+++ b/src/renderer/allocator/gpu.rs
@@ -36,11 +36,10 @@ impl Allocate for Allocator {
         size: usize,
         usage: vk::BufferUsageFlags,
     ) -> RendererResult<(vk::Buffer, Self::Memory)> {
-        let buffer_info = vk::BufferCreateInfo::builder()
+        let buffer_info = vk::BufferCreateInfo::default()
             .size(size as _)
             .usage(usage)
-            .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .build();
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
 
         let buffer = unsafe { device.create_buffer(&buffer_info, None)? };
         let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
@@ -72,7 +71,7 @@ impl Allocate for Allocator {
             depth: 1,
         };
 
-        let image_info = vk::ImageCreateInfo::builder()
+        let image_info = vk::ImageCreateInfo::default()
             .image_type(vk::ImageType::TYPE_2D)
             .extent(extent)
             .mip_levels(1)

--- a/src/renderer/allocator/vkmem.rs
+++ b/src/renderer/allocator/vkmem.rs
@@ -35,11 +35,10 @@ impl Allocate for Allocator {
         size: usize,
         usage: vk::BufferUsageFlags,
     ) -> RendererResult<(vk::Buffer, Self::Memory)> {
-        let buffer_info = vk::BufferCreateInfo::builder()
+        let buffer_info = vk::BufferCreateInfo::default()
             .size(size as _)
             .usage(usage)
-            .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .build();
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
 
         let buffer_alloc_info = AllocationCreateInfo {
             usage: MemoryUsage::AutoPreferHost,
@@ -67,7 +66,7 @@ impl Allocate for Allocator {
             depth: 1,
         };
 
-        let image_info = vk::ImageCreateInfo::builder()
+        let image_info = vk::ImageCreateInfo::default()
             .image_type(vk::ImageType::TYPE_2D)
             .extent(extent)
             .mip_levels(1)

--- a/src/renderer/vulkan.rs
+++ b/src/renderer/vulkan.rs
@@ -23,15 +23,14 @@ pub fn create_vulkan_descriptor_set_layout(
     device: &Device,
 ) -> RendererResult<vk::DescriptorSetLayout> {
     log::debug!("Creating vulkan descriptor set layout");
-    let bindings = [vk::DescriptorSetLayoutBinding::builder()
+    let bindings = [vk::DescriptorSetLayoutBinding::default()
         .binding(0)
         .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
         .descriptor_count(1)
-        .stage_flags(vk::ShaderStageFlags::FRAGMENT)
-        .build()];
+        .stage_flags(vk::ShaderStageFlags::FRAGMENT)];
 
     let descriptor_set_create_info =
-        vk::DescriptorSetLayoutCreateInfo::builder().bindings(&bindings);
+        vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
 
     unsafe { Ok(device.create_descriptor_set_layout(&descriptor_set_create_info, None)?) }
 }
@@ -50,7 +49,7 @@ pub(crate) fn create_vulkan_pipeline_layout(
     }];
 
     let descriptor_set_layouts = [descriptor_set_layout];
-    let layout_info = vk::PipelineLayoutCreateInfo::builder()
+    let layout_info = vk::PipelineLayoutCreateInfo::default()
         .set_layouts(&descriptor_set_layouts)
         .push_constant_ranges(&push_const_range);
     let pipeline_layout = unsafe { device.create_pipeline_layout(&layout_info, None)? };
@@ -70,61 +69,55 @@ pub(crate) fn create_vulkan_pipeline(
     let fragment_shader_source = std::include_bytes!("../shaders/shader.frag.spv");
 
     let vertex_source = read_shader_from_source(vertex_shader_source)?;
-    let vertex_create_info = vk::ShaderModuleCreateInfo::builder().code(&vertex_source);
+    let vertex_create_info = vk::ShaderModuleCreateInfo::default().code(&vertex_source);
     let vertex_module = unsafe { device.create_shader_module(&vertex_create_info, None)? };
 
     let fragment_source = read_shader_from_source(fragment_shader_source)?;
-    let fragment_create_info = vk::ShaderModuleCreateInfo::builder().code(&fragment_source);
+    let fragment_create_info = vk::ShaderModuleCreateInfo::default().code(&fragment_source);
     let fragment_module = unsafe { device.create_shader_module(&fragment_create_info, None)? };
 
     let shader_states_infos = [
-        vk::PipelineShaderStageCreateInfo::builder()
+        vk::PipelineShaderStageCreateInfo::default()
             .stage(vk::ShaderStageFlags::VERTEX)
             .module(vertex_module)
-            .name(&entry_point_name)
-            .build(),
-        vk::PipelineShaderStageCreateInfo::builder()
+            .name(&entry_point_name),
+        vk::PipelineShaderStageCreateInfo::default()
             .stage(vk::ShaderStageFlags::FRAGMENT)
             .module(fragment_module)
-            .name(&entry_point_name)
-            .build(),
+            .name(&entry_point_name),
     ];
 
-    let binding_desc = [vk::VertexInputBindingDescription::builder()
+    let binding_desc = [vk::VertexInputBindingDescription::default()
         .binding(0)
         .stride(20)
-        .input_rate(vk::VertexInputRate::VERTEX)
-        .build()];
+        .input_rate(vk::VertexInputRate::VERTEX)];
     let attribute_desc = [
-        vk::VertexInputAttributeDescription::builder()
+        vk::VertexInputAttributeDescription::default()
             .binding(0)
             .location(0)
             .format(vk::Format::R32G32_SFLOAT)
-            .offset(0)
-            .build(),
-        vk::VertexInputAttributeDescription::builder()
+            .offset(0),
+        vk::VertexInputAttributeDescription::default()
             .binding(0)
             .location(1)
             .format(vk::Format::R32G32_SFLOAT)
-            .offset(8)
-            .build(),
-        vk::VertexInputAttributeDescription::builder()
+            .offset(8),
+        vk::VertexInputAttributeDescription::default()
             .binding(0)
             .location(2)
             .format(vk::Format::R8G8B8A8_UNORM)
-            .offset(16)
-            .build(),
+            .offset(16),
     ];
 
-    let vertex_input_info = vk::PipelineVertexInputStateCreateInfo::builder()
+    let vertex_input_info = vk::PipelineVertexInputStateCreateInfo::default()
         .vertex_binding_descriptions(&binding_desc)
         .vertex_attribute_descriptions(&attribute_desc);
 
-    let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+    let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
         .topology(vk::PrimitiveTopology::TRIANGLE_LIST)
         .primitive_restart_enable(false);
 
-    let rasterizer_info = vk::PipelineRasterizationStateCreateInfo::builder()
+    let rasterizer_info = vk::PipelineRasterizationStateCreateInfo::default()
         .depth_clamp_enable(false)
         .rasterizer_discard_enable(false)
         .polygon_mode(vk::PolygonMode::FILL)
@@ -138,18 +131,18 @@ pub(crate) fn create_vulkan_pipeline(
 
     let viewports = [Default::default()];
     let scissors = [Default::default()];
-    let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+    let viewport_info = vk::PipelineViewportStateCreateInfo::default()
         .viewports(&viewports)
         .scissors(&scissors);
 
-    let multisampling_info = vk::PipelineMultisampleStateCreateInfo::builder()
+    let multisampling_info = vk::PipelineMultisampleStateCreateInfo::default()
         .sample_shading_enable(false)
         .rasterization_samples(vk::SampleCountFlags::TYPE_1)
         .min_sample_shading(1.0)
         .alpha_to_coverage_enable(false)
         .alpha_to_one_enable(false);
 
-    let color_blend_attachments = [vk::PipelineColorBlendAttachmentState::builder()
+    let color_blend_attachments = [vk::PipelineColorBlendAttachmentState::default()
         .color_write_mask(
             vk::ColorComponentFlags::R
                 | vk::ColorComponentFlags::G
@@ -162,27 +155,25 @@ pub(crate) fn create_vulkan_pipeline(
         .color_blend_op(vk::BlendOp::ADD)
         .src_alpha_blend_factor(vk::BlendFactor::ONE)
         .dst_alpha_blend_factor(vk::BlendFactor::ONE_MINUS_SRC_ALPHA)
-        .alpha_blend_op(vk::BlendOp::ADD)
-        .build()];
-    let color_blending_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        .alpha_blend_op(vk::BlendOp::ADD)];
+    let color_blending_info = vk::PipelineColorBlendStateCreateInfo::default()
         .logic_op_enable(false)
         .logic_op(vk::LogicOp::COPY)
         .attachments(&color_blend_attachments)
         .blend_constants([0.0, 0.0, 0.0, 0.0]);
 
-    let depth_stencil_state_create_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+    let depth_stencil_state_create_info = vk::PipelineDepthStencilStateCreateInfo::default()
         .depth_test_enable(options.enable_depth_test)
         .depth_write_enable(options.enable_depth_write)
         .depth_compare_op(vk::CompareOp::ALWAYS)
         .depth_bounds_test_enable(false)
-        .stencil_test_enable(false)
-        .build();
+        .stencil_test_enable(false);
 
     let dynamic_states = [vk::DynamicState::SCISSOR, vk::DynamicState::VIEWPORT];
     let dynamic_states_info =
-        vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
+        vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
 
-    let pipeline_info = vk::GraphicsPipelineCreateInfo::builder()
+    let pipeline_info = vk::GraphicsPipelineCreateInfo::default()
         .stages(&shader_states_infos)
         .vertex_input_state(&vertex_input_info)
         .input_assembly_state(&input_assembly_info)
@@ -201,7 +192,7 @@ pub(crate) fn create_vulkan_pipeline(
     let color_attachment_formats = [dynamic_rendering.color_attachment_format];
     #[cfg(feature = "dynamic-rendering")]
     let mut rendering_info = {
-        let mut rendering_info = vk::PipelineRenderingCreateInfo::builder()
+        let mut rendering_info = vk::PipelineRenderingCreateInfo::default()
             .color_attachment_formats(&color_attachment_formats);
         if let Some(depth_attachment_format) = dynamic_rendering.depth_attachment_format {
             rendering_info = rendering_info.depth_attachment_format(depth_attachment_format);
@@ -246,7 +237,7 @@ pub fn create_vulkan_descriptor_pool(
         ty: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
         descriptor_count: 1,
     }];
-    let create_info = vk::DescriptorPoolCreateInfo::builder()
+    let create_info = vk::DescriptorPoolCreateInfo::default()
         .pool_sizes(&sizes)
         .max_sets(max_sets)
         .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET);
@@ -265,7 +256,7 @@ pub fn create_vulkan_descriptor_set(
 
     let set = {
         let set_layouts = [set_layout];
-        let allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(&set_layouts);
 
@@ -279,12 +270,11 @@ pub fn create_vulkan_descriptor_set(
             image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         }];
 
-        let writes = [vk::WriteDescriptorSet::builder()
+        let writes = [vk::WriteDescriptorSet::default()
             .dst_set(set)
             .dst_binding(0)
             .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-            .image_info(&image_info)
-            .build()];
+            .image_info(&image_info)];
         device.update_descriptor_sets(&writes, &[])
     }
 
@@ -385,7 +375,7 @@ mod texture {
             // Transition the image layout and copy the buffer into the image
             // and transition the layout again to be readable from fragment shader.
             {
-                let mut barrier = vk::ImageMemoryBarrier::builder()
+                let mut barrier = vk::ImageMemoryBarrier::default()
                     .old_layout(vk::ImageLayout::UNDEFINED)
                     .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                     .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -399,8 +389,7 @@ mod texture {
                         layer_count: 1,
                     })
                     .src_access_mask(vk::AccessFlags::empty())
-                    .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
-                    .build();
+                    .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
 
                 unsafe {
                     device.cmd_pipeline_barrier(
@@ -414,7 +403,7 @@ mod texture {
                     )
                 };
 
-                let region = vk::BufferImageCopy::builder()
+                let region = vk::BufferImageCopy::default()
                     .buffer_offset(0)
                     .buffer_row_length(0)
                     .buffer_image_height(0)
@@ -429,8 +418,7 @@ mod texture {
                         width,
                         height,
                         depth: 1,
-                    })
-                    .build();
+                    });
                 unsafe {
                     device.cmd_copy_buffer_to_image(
                         command_buffer,
@@ -460,7 +448,7 @@ mod texture {
             }
 
             let image_view = {
-                let create_info = vk::ImageViewCreateInfo::builder()
+                let create_info = vk::ImageViewCreateInfo::default()
                     .image(image)
                     .view_type(vk::ImageViewType::TYPE_2D)
                     .format(vk::Format::R8G8B8A8_UNORM)
@@ -476,7 +464,7 @@ mod texture {
             };
 
             let sampler = {
-                let sampler_info = vk::SamplerCreateInfo::builder()
+                let sampler_info = vk::SamplerCreateInfo::default()
                     .mag_filter(vk::Filter::LINEAR)
                     .min_filter(vk::Filter::LINEAR)
                     .address_mode_u(vk::SamplerAddressMode::REPEAT)
@@ -523,7 +511,7 @@ mod texture {
         executor: F,
     ) -> RendererResult<R> {
         let command_buffer = {
-            let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            let alloc_info = vk::CommandBufferAllocateInfo::default()
                 .level(vk::CommandBufferLevel::PRIMARY)
                 .command_pool(pool)
                 .command_buffer_count(1);
@@ -534,7 +522,7 @@ mod texture {
 
         // Begin recording
         {
-            let begin_info = vk::CommandBufferBeginInfo::builder()
+            let begin_info = vk::CommandBufferBeginInfo::default()
                 .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
             unsafe { device.begin_command_buffer(command_buffer, &begin_info)? };
         }
@@ -547,9 +535,7 @@ mod texture {
 
         // Submit and wait
         {
-            let submit_info = vk::SubmitInfo::builder()
-                .command_buffers(&command_buffers)
-                .build();
+            let submit_info = vk::SubmitInfo::default().command_buffers(&command_buffers);
             let submit_infos = [submit_info];
             unsafe {
                 device.queue_submit(queue, &submit_infos, vk::Fence::null())?;


### PR DESCRIPTION
Tested on Windows.

Note the use of the `ash-0.38` branch of `gpu-allocator`.