### PR TITLE
Add options for subpass and multisampling

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -44,6 +44,8 @@ pub struct Options {
     pub enable_depth_write: bool,
     /// Subpass for the graphics pipeline.
     pub subpass: u32,
+    /// Sample count for the graphics pipeline multisampling state
+    pub multisampling: vk::SampleCountFlags,
 }
 
 impl Default for Options {
@@ -53,6 +55,7 @@ impl Default for Options {
             enable_depth_test: false,
             enable_depth_write: false,
             subpass: 0,
+            multisampling: vk::SampleCountFlags::TYPE_1
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -42,6 +42,8 @@ pub struct Options {
     /// Note that depth writes are always disabled when enable_depth_test is false.
     /// See <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDepthStencilStateCreateInfo.html>
     pub enable_depth_write: bool,
+    /// Subpass for the graphics pipeline.
+    pub subpass: u32,
 }
 
 impl Default for Options {
@@ -50,6 +52,7 @@ impl Default for Options {
             in_flight_frames: 1,
             enable_depth_test: false,
             enable_depth_write: false,
+            subpass: 0,
         }
     }
 }

--- a/src/renderer/vulkan.rs
+++ b/src/renderer/vulkan.rs
@@ -137,7 +137,7 @@ pub(crate) fn create_vulkan_pipeline(
 
     let multisampling_info = vk::PipelineMultisampleStateCreateInfo::default()
         .sample_shading_enable(false)
-        .rasterization_samples(vk::SampleCountFlags::TYPE_1)
+        .rasterization_samples(options.multisampling)
         .min_sample_shading(1.0)
         .alpha_to_coverage_enable(false)
         .alpha_to_one_enable(false);

--- a/src/renderer/vulkan.rs
+++ b/src/renderer/vulkan.rs
@@ -183,7 +183,8 @@ pub(crate) fn create_vulkan_pipeline(
         .color_blend_state(&color_blending_info)
         .depth_stencil_state(&depth_stencil_state_create_info)
         .dynamic_state(&dynamic_states_info)
-        .layout(pipeline_layout);
+        .layout(pipeline_layout)
+        .subpass(options.subpass);
 
     #[cfg(not(feature = "dynamic-rendering"))]
     let pipeline_info = pipeline_info.render_pass(render_pass);


### PR DESCRIPTION
Adds options for subpass and multisampling when creating the graphics pipeline.
Say that you have a renderpass with a single subpass that is multisampled (4x) and resolved directly to the surface image. For this case you could set the option `multisampling` to `vk::SampleCountFlags::TYPE_4`, and it would render correctly.

However, if you have 2 subpasses, for example: 
 -  3D render (4x multisampling) ---resolve--> 2D UI render (no multisampling)
You maybe want to render to the second subpass. For this case you could set the option `subpass` to `1`.